### PR TITLE
chore: setup pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ CMakeUserPresets.json
 
 # uncrustify specific stuff
 defaults.cfg
+
+# vscode specific stuff
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,58 +1,19 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
-# venv
+# virtualenv for pre-commit
 venv/
 
-# cmake specific stuff
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
-CMakeUserPresets.json
+# vscode workspace configuration
+.vscode/
 
-# macOS specific stuff
+# clang *.plist files
 *.plist
 
-# uncrustify specific stuff
-defaults.cfg
+# cmake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+CTestTestfile.cmake
+Makefile
+compile_commands.json
 
-# vscode specific stuff
-.vscode/
+# project binary
+dgSqlite

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# venv
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,17 @@
 
 # venv
 venv/
+
+# cmake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@
 # venv
 venv/
 
-# cmake
+# cmake specific stuff
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles
@@ -48,5 +48,8 @@ CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
 
-# macOS
-main.plist
+# macOS specific stuff
+*.plist
+
+# uncrustify specific stuff
+defaults.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 CMakeUserPresets.json
+
+# macOS
+main.plist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+default_install_hook_types: [pre-commit, commit-msg]
+repos:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.27.0
+    hooks:
+      - id: commitizen
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: clang-format
+        args: [--style=Google]
+      - id: clang-tidy
+      - id: oclint
+      - id: uncrustify
+      - id: cppcheck
+      - id: cpplint
+      - id: include-what-you-use
+        args: ["-Xiwyu", "--error=1"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.27.0
     hooks:
@@ -8,10 +15,18 @@ repos:
     rev: v1.3.5
     hooks:
       - id: clang-format
-        args: [--style=Google]
+        args: [-Werror, -i, --style=llvm]
       - id: clang-tidy
+        args:
+          [
+            --fix,
+            --fix-errors,
+            --fix-notes,
+            --format-style=llvm,
+            -p=build/compile_commands.json,
+          ]
       - id: oclint
-      - id: uncrustify
+        args: [-p=build/compile_commands.json]
       - id: cppcheck
       - id: cpplint
       - id: include-what-you-use

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@
 cmake_minimum_required(VERSION 3.29.6)
 
 # Define the project name and version
-project(SimpleSqliteClone VERSION 0.0.1)
+project(dgSqlite VERSION 0.0.1)
 
 # Specify the C++ standard
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Add the executable
-add_executable(SimpleSqliteClone src/main.cpp)
+add_executable(dgSqlite src/main.cpp)
 
 # Optionally, link libraries (example)
 # target_link_libraries(MyProject SomeLibrary)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Specify the minimum version of CMake required
+cmake_minimum_required(VERSION 3.29.6)
+
+# Define the project name and version
+project(SimpleSqliteClone VERSION 0.0.1)
+
+# Specify the C++ standard
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Add the executable
+add_executable(SimpleSqliteClone src/main.cpp)
+
+# Optionally, link libraries (example)
+# target_link_libraries(MyProject SomeLibrary)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,62 @@
 
 This is an attempt to build a simple _in-process_ DB i.e., `SQLite` to grok its internal workings from the very ground up.
 
-`Clang` is used as the compiler front end for this project.
+`clang` is used as the compiler front end for this project.
+
+`cmake` is used as the build-system generator.
+
+## Housekeeping - `pre-commit` hooks
+
+[`pre-commit`](https://pre-commit.com/#install) hooks are used for general _code_ housekeeping.
+
+Ensure a `python` virtual environment and install [`pre-commit`](https://pre-commit.com/#install) as per instructions [here](https://pre-commit.com/#1-install-pre-commit).
+
+The following hooks are used in this repository:
+
+1. Out of the box hooks from [`pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks).
+2. [`commitizen`](https://github.com/commitizen-tools/commitizen): For enforcing [conventional commits](https://www.conventionalcommits.org/) specification for commit messages.
+3. [`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks): For `C++` specific code formatting and static analysis.
+
+### Installing dependencies for [`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks)
+
+[`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks) assumes all dependencies are pre-installed. Therefore, manually install the required dependencies as per instructions [here](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#installation).
+
+### `macOS` specific tweaks
+
+1. `macOS` ships with `clang`, but not `clang-format` or `clang-tidy`. A convenient way to get these working on `macOS` is to install `llvm` and then using `clang-format` and `clang-tidy` that come shipped with it. 
+
+    However, `llvm` installed via `brew` is keg-only, which means it and its associated binaries are not symlinked to Homebrew's installation path. Therefore, `clang-format` and `clang-tidy` have to manually be symlinked to one of the directories in the environment's `PATH` to make the corresponding hooks work. Below are commands to symlink these binaries to Homebrew's installation path:
+
+    - ```sh
+        ln -s "$(brew --prefix llvm)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
+        ```
+    
+    - ```sh
+        ln -s "$(brew --prefix llvm)/bin/clang-tidy" "$(brew --prefix)/bin/clang-tidy"
+        ```
+
+2. `oclint` comes shipped with several dylibs that are dynamically loaded when `oclint` needs the specific rule to lint the source code. All these dylibs needs to be manually approved in the [Gatekeeper](https://support.apple.com/en-sg/guide/security/sec5599b66df/web) prompt. To approve all `oclint` specific dylibs in one-shot, run the following commands as per instructions [here](https://ingo-richter.io/post/2022/adding-multiple-files-to-macos-gatekeeper/):
+    - adding `OCLint` label to the dylibs:
+        ```sh
+        find $(brew --prefix)/Caskroom/oclint/22.02/oclint-22.02/lib/oclint -name "*.dylib" -print0 | xargs -0 sudo spctl --add --label "OCLint"
+        ```
+    - enabling all labelled dylibs:
+        ```sh
+        sudo spctl --enable --label "OCLint"
+        ```
+
+### Generating compilation database
+
+`clang-tidy` and `oclint` both expect a [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html). Run the following CLI command in the project's root directory to generate one (ensure `cmake` is pre-installed in the environment):
+
+    ```sh
+    cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ./
+    ```
+
+### Installing the hooks
+Run the following CLI command to install the hooks:
+
+```sh
+pre-commit install
+```
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
-## A simple `SQLite` clone written in `C++`
+# A simple `SQLite` clone written in `C++`
 
 This is an attempt to build a simple _in-process_ DB i.e., `SQLite` to grok its internal workings from the very ground up.
 
-`clang` is used as the compiler front end for this project.
+- `clang++` is used as the compiler front end for this project.
+- `cmake` is used as the build-system generator.
+- `make` is used as the build system.
 
-`cmake` is used as the build-system generator.
+## Generating build files using `CMake`
+
+Run the following CLI command in the project's root directory to generate the build files:
+
+```sh
+cmake -Bbuild -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ./
+```
+
+- Explicitly set `clang++` as the `C++` compiler using `-DCMAKE_CXX_COMPILER=clang++`.
+- Generate a compilation database using `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
 ## Housekeeping - `pre-commit` hooks
 
@@ -20,44 +31,50 @@ The following hooks are used in this repository:
 
 ### Installing dependencies for [`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks)
 
-[`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks) assumes all dependencies are pre-installed. Therefore, manually install the required dependencies as per instructions [here](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#installation).
+[`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks) assumes all dependencies are pre-installed. Therefore, manually install the required dependencies as per instructions [here](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#installation). Only `clang-format` is used for code formatting.
 
 ### `macOS` specific tweaks
 
-1. `macOS` ships with `clang`, but not `clang-format` or `clang-tidy`. A convenient way to get these working on `macOS` is to install `llvm` and then using `clang-format` and `clang-tidy` that come shipped with it. 
+1. `macOS` ships with `clang++`, but not `clang-format` or `clang-tidy`. A convenient way to get these working on `macOS` is to install `llvm` and then using `clang-format` and `clang-tidy` that come shipped with it.
 
-    However, `llvm` installed via `brew` is keg-only, which means it and its associated binaries are not symlinked to Homebrew's installation path. Therefore, `clang-format` and `clang-tidy` have to manually be symlinked to one of the directories in the environment's `PATH` to make the corresponding hooks work. Below are commands to symlink these binaries to Homebrew's installation path:
+   However, `llvm` installed via `brew` is keg-only, which means it and its associated binaries are not symlinked to Homebrew's installation path. Therefore, `clang-format` and `clang-tidy` have to manually be symlinked to one of the directories in the environment's `PATH` to make the corresponding hooks work. Below are commands to symlink these binaries to Homebrew's installation path:
 
-    - ```sh
-        ln -s "$(brew --prefix llvm)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
-        ```
-    
-    - ```sh
-        ln -s "$(brew --prefix llvm)/bin/clang-tidy" "$(brew --prefix)/bin/clang-tidy"
-        ```
+   - ```sh
+       ln -s "$(brew --prefix llvm)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
+     ```
+
+   - ```sh
+       ln -s "$(brew --prefix llvm)/bin/clang-tidy" "$(brew --prefix)/bin/clang-tidy"
+     ```
 
 2. `oclint` comes shipped with several dylibs that are dynamically loaded when `oclint` needs the specific rule to lint the source code. All these dylibs needs to be manually approved in the [Gatekeeper](https://support.apple.com/en-sg/guide/security/sec5599b66df/web) prompt. To approve all `oclint` specific dylibs in one-shot, run the following commands as per instructions [here](https://ingo-richter.io/post/2022/adding-multiple-files-to-macos-gatekeeper/):
-    - adding `OCLint` label to the dylibs:
-        ```sh
-        find $(brew --prefix)/Caskroom/oclint/22.02/oclint-22.02/lib/oclint -name "*.dylib" -print0 | xargs -0 sudo spctl --add --label "OCLint"
-        ```
-    - enabling all labelled dylibs:
-        ```sh
-        sudo spctl --enable --label "OCLint"
-        ```
-
-### Generating compilation database
-
-`clang-tidy` and `oclint` both expect a [compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html). Run the following CLI command in the project's root directory to generate one (ensure `cmake` is pre-installed in the environment):
-
-    ```sh
-    cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ./
-    ```
+   - adding `OCLint` label to the dylibs:
+     ```sh
+     find $(brew --prefix)/Caskroom/oclint/22.02/oclint-22.02/lib/oclint -name "*.dylib" -print0 | xargs -0 sudo spctl --add --label "OCLint"
+     ```
+   - enabling all labelled dylibs:
+     ```sh
+     sudo spctl --enable --label "OCLint"
+     ```
 
 ### Installing the hooks
+
 Run the following CLI command to install the hooks:
 
 ```sh
 pre-commit install
 ```
 
+## Building and running the project binary
+
+Run the following CLI command in the project's root directory to build the binary:
+
+```sh
+make -C build/
+```
+
+Run the following CLI command in the project's root directory to run the built binary:
+
+```sh
+./build/dgSqlite
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,5 @@
+// Copyright [2024] <Divyansh Gupta>
+
+int main() {
+    return 0; 
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,7 @@
 // Copyright [2024] <Divyansh Gupta>
+#include <iostream>
 
 int main() {
-    return 0; 
+  std::cout << "Hello World!";
+  return 0;
 }


### PR DESCRIPTION
## Description

1. Setup `CMakeLists.txt` to generate build files using `CMake`.
2. Setup `.pre-commit-config.yaml` to install and apply pre-commit hooks.
3. Updated `README.md` with instructions on how to install the hooks and their dependencies.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The hooks were manually tested to ensure they worked correctly, as recommended [here](https://github.com/pocc/pre-commit-hooks/?tab=readme-ov-file#example-usage).