### PR TITLE
feat: implement REPL interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,5 @@ venv/
 # clang *.plist files
 *.plist
 
-# cmake generated files
-CMakeFiles/
-CMakeCache.txt
-cmake_install.cmake
-CTestTestfile.cmake
-Makefile
-compile_commands.json
-
-# project binary
-dgSqlite
+# build directory
+build/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,23 +11,30 @@ repos:
     rev: v3.27.0
     hooks:
       - id: commitizen
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  - repo: local
     hooks:
       - id: clang-format
-        args: [-Werror, -i, --style=llvm]
+        name: clang-format
+        entry: clang-format -Werror -i --style=llvm
+        language: system
+        types_or: [c++]
       - id: clang-tidy
-        args:
-          [
-            --fix,
-            --fix-errors,
-            --fix-notes,
-            --format-style=llvm,
-            -p=build/compile_commands.json,
-          ]
-      - id: oclint
-        args: [-p=build/compile_commands.json]
+        name: clang-tidy
+        entry: clang-tidy --fix --fix-errors --fix-notes --format-style=llvm -p=build/compile_commands.json
+        language: system
+        types_or: [c++]
       - id: cppcheck
+        name: cppcheck
+        entry: cppcheck -Iinclude/ --suppress=unmatchedSuppression --suppress=missingIncludeSystem --suppress=unusedFunction --suppress=unknownMacro
+        language: system
+        types_or: [c++]
       - id: cpplint
+        name: cpplint
+        entry: cpplint --filter=-legal/copyright,-whitespace/comments,-whitespace/blank_line,-build/include_order,-build/include_subdir
+        language: system
+        types_or: [c++]
       - id: include-what-you-use
-        args: ["-Xiwyu", "--error=1"]
+        name: include-what-you-use
+        entry: include-what-you-use -Xiwyu --error=1 -Iinclude/ -std=c++23
+        language: system
+        types_or: [c++]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,78 @@
 cmake_minimum_required(VERSION 3.29.6)
 
 # Define the project name and version
-project(dgSqlite VERSION 0.0.1)
+project(dgSqlite VERSION 0.0.1 LANGUAGES CXX)
 
 # Specify the C++ standard
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Add the executable
-add_executable(dgSqlite src/main.cpp)
+# Add global C++ flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fcolor-diagnostics -fansi-escape-codes -g -Wall")
 
-# Optionally, link libraries (example)
-# target_link_libraries(MyProject SomeLibrary)
+# Define source code library
+add_library(source_code_lib OBJECT
+    ${PROJECT_SOURCE_DIR}/src/IOUtils.cpp
+)
+
+# Specify include directories for the source code library
+target_include_directories(
+    source_code_lib PUBLIC ${PROJECT_SOURCE_DIR}/include
+)
+
+# Add the executable
+add_executable(dgSqlite
+    ${PROJECT_SOURCE_DIR}/src/main.cpp
+)
+
+# Link the executable with source code library
+target_link_libraries(
+    dgSqlite PRIVATE source_code_lib
+)
+
+# Include FetchContent
+include(FetchContent)
+
+# Declare and fetch GoogleTest
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/f8d7d77c06936315286eb55f8de22cd23c188571.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+# Define tests library
+add_library(tests_lib OBJECT
+    ${PROJECT_SOURCE_DIR}/tests/test_IOUtils.cpp
+)
+
+# Specify include directories for the tests library
+target_include_directories(
+    tests_lib PUBLIC ${gtest_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+
+# Add test executable
+add_executable(
+    dgSqliteTests
+    ${PROJECT_SOURCE_DIR}/tests/test_main.cpp
+)
+
+# Link GoogleTest to test executable
+target_link_libraries(
+    dgSqliteTests
+    source_code_lib
+    tests_lib
+    GTest::gtest_main
+)
+
+# Include the GoogleTest module
+include(GoogleTest)
+
+# Include CTest module
+include(CTest)
+
+# Enable testing
+enable_testing()
+
+# Discover and add test cases to CTest
+gtest_discover_tests(dgSqliteTests)

--- a/README.md
+++ b/README.md
@@ -3,19 +3,8 @@
 This is an attempt to build a simple _in-process_ DB i.e., `SQLite` to grok its internal workings from the very ground up.
 
 - `clang++` is used as the compiler front end for this project.
-- `cmake` is used as the build-system generator.
+- `cmake` is used as the build system generator.
 - `make` is used as the build system.
-
-## Generating build files using `CMake`
-
-Run the following CLI command in the project's root directory to generate the build files:
-
-```sh
-cmake -Bbuild -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ./
-```
-
-- Explicitly set `clang++` as the `C++` compiler using `-DCMAKE_CXX_COMPILER=clang++`.
-- Generate a compilation database using `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`.
 
 ## Housekeeping - `pre-commit` hooks
 
@@ -27,35 +16,31 @@ The following hooks are used in this repository:
 
 1. Out of the box hooks from [`pre-commit/pre-commit-hooks`](https://github.com/pre-commit/pre-commit-hooks).
 2. [`commitizen`](https://github.com/commitizen-tools/commitizen): For enforcing [conventional commits](https://www.conventionalcommits.org/) specification for commit messages.
-3. [`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks): For `C++` specific code formatting and static analysis.
+3. _Custom_ hooks using binaries available in the `PATH` for `C++` specific code formatting and static analysis. The following are used for this purpose:
 
-### Installing dependencies for [`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks)
+   - `clang-format`
+   - `clang-tidy`
+   - `cppcheck`
+   - `cpplint`
+   - `include-what-you-use`
 
-[`pocc/pre-commit-hooks`](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#pre-commit-hooks) assumes all dependencies are pre-installed. Therefore, manually install the required dependencies as per instructions [here](https://github.com/pocc/pre-commit-hooks?tab=readme-ov-file#installation). Only `clang-format` is used for code formatting.
+   Specifically for `include-what-you-use`, care needs to be taken to install the version compatible with the particular `clang++` version being used, as per instructions [here](https://github.com/include-what-you-use/include-what-you-use?tab=readme-ov-file#clang-compatibility).
+
+   `clang-tidy` requires a compilation database to work. Instructions to generate it are in the [<b>Generating build files using `CMake`</b>](#generating-build-files-using-cmake) section below.
 
 ### `macOS` specific tweaks
 
-1. `macOS` ships with `clang++`, but not `clang-format` or `clang-tidy`. A convenient way to get these working on `macOS` is to install `llvm` and then using `clang-format` and `clang-tidy` that come shipped with it.
+`macOS` ships with `clang++`, but not `clang-format` or `clang-tidy`. A convenient way to get these working on `macOS` is to install `llvm` and then using `clang-format` and `clang-tidy` that come shipped with it.
 
-   However, `llvm` installed via `brew` is keg-only, which means it and its associated binaries are not symlinked to Homebrew's installation path. Therefore, `clang-format` and `clang-tidy` have to manually be symlinked to one of the directories in the environment's `PATH` to make the corresponding hooks work. Below are commands to symlink these binaries to Homebrew's installation path:
+However, `llvm` installed via `brew` is keg-only, which means it and its associated binaries are not symlinked to Homebrew's installation path. Therefore, `clang-format` and `clang-tidy` have to manually be symlinked to one of the directories in the environment's `PATH` to make the corresponding hooks work. Below are commands to symlink these binaries to Homebrew's installation path:
 
-   - ```sh
-       ln -s "$(brew --prefix llvm)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
-     ```
+- ```sh
+    ln -s "$(brew --prefix llvm)/bin/clang-format" "$(brew --prefix)/bin/clang-format"
+  ```
 
-   - ```sh
-       ln -s "$(brew --prefix llvm)/bin/clang-tidy" "$(brew --prefix)/bin/clang-tidy"
-     ```
-
-2. `oclint` comes shipped with several dylibs that are dynamically loaded when `oclint` needs the specific rule to lint the source code. All these dylibs needs to be manually approved in the [Gatekeeper](https://support.apple.com/en-sg/guide/security/sec5599b66df/web) prompt. To approve all `oclint` specific dylibs in one-shot, run the following commands as per instructions [here](https://ingo-richter.io/post/2022/adding-multiple-files-to-macos-gatekeeper/):
-   - adding `OCLint` label to the dylibs:
-     ```sh
-     find $(brew --prefix)/Caskroom/oclint/22.02/oclint-22.02/lib/oclint -name "*.dylib" -print0 | xargs -0 sudo spctl --add --label "OCLint"
-     ```
-   - enabling all labelled dylibs:
-     ```sh
-     sudo spctl --enable --label "OCLint"
-     ```
+- ```sh
+    ln -s "$(brew --prefix llvm)/bin/clang-tidy" "$(brew --prefix)/bin/clang-tidy"
+  ```
 
 ### Installing the hooks
 
@@ -64,6 +49,22 @@ Run the following CLI command to install the hooks:
 ```sh
 pre-commit install
 ```
+
+## Generating build files using `CMake`
+
+Run the following CLI command in the project's root directory to generate the build files:
+
+```sh
+cmake \
+-DCMAKE_BUILD_TYPE:STRING=Debug \
+-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
+-DCMAKE_CXX_COMPILER:FILEPATH=path/to/clang++ \
+-S. \
+-B./build \
+-G="Unix Makefiles"
+```
+
+The `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` generates the compilation database.
 
 ## Building and running the project binary
 

--- a/include/IOUtils.hpp
+++ b/include/IOUtils.hpp
@@ -1,0 +1,11 @@
+#ifndef INCLUDE_IOUTILS_HPP_
+#define INCLUDE_IOUTILS_HPP_
+
+#include <__fwd/istream.h>
+#include <string>
+
+void print_prompt();
+
+void read_input_from_stream(std::string *inputBuffer, std::istream &istream);
+
+#endif // INCLUDE_IOUTILS_HPP_

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,0 +1,9 @@
+#ifndef INCLUDE_CONSTANTS_HPP_
+#define INCLUDE_CONSTANTS_HPP_
+
+// define string
+const char CMD_PREFIX[] = "dgDB > ";
+const char ERROR_READING_INPUT_STREAM[] = "Error reading input\n";
+const char EXIT_STRING[] = ".exit";
+
+#endif // INCLUDE_CONSTANTS_HPP_

--- a/src/IOUtils.cpp
+++ b/src/IOUtils.cpp
@@ -1,0 +1,15 @@
+#include "IOUtils.hpp"
+#include "constants.hpp"
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+void print_prompt() { std::cout << CMD_PREFIX; }
+
+void read_input_from_stream(std::string *inputBuffer, std::istream &istream) {
+  std::getline(istream, *inputBuffer);
+
+  if ((*inputBuffer).length() == 0) {
+    throw std::runtime_error(ERROR_READING_INPUT_STREAM);
+  }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,31 @@
-// Copyright [2024] <Divyansh Gupta>
+#include "IOUtils.hpp"
+#include <constants.hpp>
+#include <format>
 #include <iostream>
+#include <stdexcept>
+#include <stdlib.h>
+#include <string>
 
-int main() {
-  std::cout << "Hello World!";
+int main(int argc, char *argv[]) {
+  std::string inputBuffer;
+
+  while (true) {
+    print_prompt();
+
+    try {
+      read_input_from_stream(&inputBuffer, std::cin);
+
+      if (inputBuffer == EXIT_STRING)
+        exit(EXIT_SUCCESS);
+
+      std::string outString =
+          std::format("Unrecognized command '{0}'.\n", inputBuffer);
+      std::cout << outString;
+
+    } catch (const std::runtime_error &e) {
+      exit(EXIT_FAILURE);
+    }
+  }
+
   return 0;
 }

--- a/tests/test_IOUtils.cpp
+++ b/tests/test_IOUtils.cpp
@@ -1,0 +1,42 @@
+#include "IOUtils.hpp"
+#include <format>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+TEST(ReadInput, HandlesValidInput) {
+  // setup input buffer
+  std::string inputBuffer;
+
+  // populate prepare mock data
+  std::string lineOne = "line1";
+  std::string lineTwo = "line2";
+  std::string mockData = std::format("{0}\n{1}", lineOne, lineTwo);
+
+  // init string stream with mockData
+  std::istringstream inputStream(mockData);
+
+  // read mockData from stream
+  read_input_from_stream(&inputBuffer, inputStream);
+
+  // assert string before newline was correctly read
+  EXPECT_EQ(inputBuffer, lineOne);
+}
+
+TEST(ReadInput, ThrowsRuntimeErrorForInvalidInput) {
+  // setup input buffer
+  std::string inputBuffer;
+
+  // populate prepare mock data
+  std::string invalidData = "\n";
+
+  // init string stream with mockData
+  std::istringstream inputStream(invalidData);
+
+  // assert runtime exception is throws
+
+  // cppcheck-suppress unknownMacro
+  EXPECT_THROW(read_input_from_stream(&inputBuffer, inputStream);
+               , std::runtime_error);
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,7 @@
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

The following changes were implemented:
1. Setup a simple _REPL_ interface which uses `std::getline` to read input from `stdin`.
2. Enhanced the configuration in `CMakeLists.txt` to:
    - properly configure `CMAKE_CXX_FLAGS`
    - correctly link code and header files to executables using `add_library` and `target_include_directories` functions
    - download [`googletest`](https://google.github.io/googletest/) and link it to the test executable
3. Implemented tests for the `read_input_from_stream` function in `src/IOUtils.cpp`.
4. Changed the `.pre-commit-config.yaml` to not use hooks from [pocc/pre-commit-hooks](https://github.com/pocc/pre-commit-hooks) and instead use custom hooks making use of binaries in the `PATH`.
5. Updated the `README.md` to reflect changes in `pre-commit` configuration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All test cases pass.